### PR TITLE
feat: Log "restaurant_reviews_checked" event on ReviewsSection display

### DIFF
--- a/app/src/main/java/com/example/campusbites/presentation/ui/screens/subscreens/restaurantDetail/ReviewsSection.kt
+++ b/app/src/main/java/com/example/campusbites/presentation/ui/screens/subscreens/restaurantDetail/ReviewsSection.kt
@@ -7,17 +7,25 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.campusbites.presentation.ui.components.CommentCard
 import com.example.campusbites.presentation.ui.viewmodels.RestaurantDetailViewModel
+import com.google.firebase.analytics.ktx.analytics
+import com.google.firebase.ktx.Firebase
 
 @Composable
 fun ReviewsSection(
     restaurantDetailViewModel: RestaurantDetailViewModel = viewModel()
 ) {
     val uiState = restaurantDetailViewModel.uiState.collectAsState().value
+
+    // Registrar un evento cada vez que se muestra la sección de reseñas
+    LaunchedEffect(Unit) {
+        Firebase.analytics.logEvent("restaurant_reviews_checked", null)
+    }
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(text = "Reseñas", style = MaterialTheme.typography.displayMedium)


### PR DESCRIPTION
This commit adds Firebase Analytics event logging to the `ReviewsSection` composable.

**Key Changes:**

-   **Event Logging:**
    -   Implemented `Firebase.analytics.logEvent("restaurant_reviews_checked", null)` within a `LaunchedEffect` to log a custom event named "restaurant_reviews_checked" each time the `ReviewsSection` is displayed.
    - The `restaurant_reviews_checked` event is logged with no parameters.